### PR TITLE
Fix deprecation warning for boost/test/floating_point_comparison.hpp

### DIFF
--- a/tests/unit/aux.cpp
+++ b/tests/unit/aux.cpp
@@ -7,7 +7,12 @@
 
 #include <limits>
 #include <string>
+#include <boost/version.hpp>
+#if BOOST_VERSION < 105900
 #include <boost/test/floating_point_comparison.hpp>
+#else
+#include <boost/test/tools/floating_point_comparison.hpp>
+#endif
 #include <boost/test/unit_test.hpp>
 #include "slhaea.h"
 


### PR DESCRIPTION
`boost/test/floating_point_comparison.hpp` is replaced by `boost/test/tools/floating_point_comparison.hpp` since boost 1.59.